### PR TITLE
[FIX] vale: v3.0.5 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,15 @@ With the repository cloned, proceed to the [Add as VS Code extension](#add-as-vs
 
 ## Update
 
-To update to the latest changes from this repository, simply pull the latest changes from the `master` branch.
+This repository uses Vale `3.0.5`. Please make sure this version, or a version above, of Vale is installed by running `vale --version` in the terminal.
 
-To do so, navigate to the **odoo-vale-linter** project folder in the terminal. Then, run the following command:
+To update Vale, run the following command in the terminal depending on your operating system:
+
+- Mac: `brew upgrade vale`
+- Windows: `choco upgrade vale`
+- Linux:
+
+To update to the latest changes from this repository, simply pull the latest changes from the `master` branch by navigating to the **odoo-vale-linter** project folder in the terminal, and running the following command:
 
 ```shell
 git pull origin master

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Set the desired Vale version
-VALE_VERSION="2.28.0"
+VALE_VERSION="3.0.5"
 
 # Define the URL for the Vale binary
 VALE_URL="https://github.com/errata-ai/vale/releases/download/v$VALE_VERSION/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -1,11 +1,14 @@
-[t/T]imesheet
-[t/T]imesheets
 classes
 code-column
 configurator
 custom-css
 custom-js
 hide-page-toc
+titlesonly
+show-content
+show-toc
+[t/T]imesheet
+[t/T]imesheets
 kanban
 massmails
 nosearch
@@ -15,8 +18,6 @@ preconfigured
 pricelist
 putaway
 SaaS
-show-content
-show-toc
 sublocation
 tradeshow
 unsubscription


### PR DESCRIPTION
This PR updates the Vale Vocab directive to be compatible with the [latest update](https://github.com/errata-ai/vale/releases/tag/v3.0.0) for Vale 3.0+.

Added instructions to the **Update** section for upgrading an installed version of Vale for Mac and Windows, needs Linux upgrade instructions.

This PR should fix the issue Windows users were having where they would receive the following error when trying to run Vale:
> E100 [vocab] Runtime error
> 'config\vocabularies/Docs' directory does not exist