### PR TITLE
[FIX] Odoo: v1 bugfix

### DIFF
--- a/styles/Odoo/FutureTense.yml
+++ b/styles/Odoo/FutureTense.yml
@@ -4,8 +4,8 @@ message: "'%s' is future tense."
 level: suggestion
 ignorecase: true
 tokens:
-  - will( |\n)be
-  - will
-  - shall
-  - going( |\n)to
-  - about( |\n)to
+  - it will( |\n)be
+  - it will
+  - it shall
+  - is going( |\n)to
+  - is about( |\n)to

--- a/styles/Odoo/StartSentence.yml
+++ b/styles/Odoo/StartSentence.yml
@@ -5,7 +5,7 @@ scope: paragraph
 action:
   name: remove
 tokens:
-  - ^But
-  - ^However
-  - ^There is
-  - ^There are
+  - But
+  - However
+  - There is
+  - There are

--- a/styles/Odoo/WordList.yml
+++ b/styles/Odoo/WordList.yml
@@ -60,6 +60,6 @@ swap:
   synch: sync
   tablename: table name
   touch: tap
-  url: URL
+  url|Url: URL
   vs\.: versus
   World Wide Web: web

--- a/styles/config/vocabularies/Docs/accept.txt
+++ b/styles/config/vocabularies/Docs/accept.txt
@@ -21,3 +21,8 @@ SaaS
 sublocation
 tradeshow
 unsubscription
+Todo
+[a/A]pprovers
+[URL/URLs]
+[h/H]elpdesk
+[c/C]hatbot

--- a/testdata/FutureTense/test.ct
+++ b/testdata/FutureTense/test.ct
@@ -1,7 +1,4 @@
 $ cdf ${ROOTDIR}
 $ vale --output=line --sort --normalize --relative --no-exit test.rst
-test.rst:1:10:Odoo.FutureTense:'will be' is future tense.
-test.rst:1:94:Odoo.FutureTense:'going to' is future tense.
-test.rst:4:6:Odoo.FutureTense:'will' is future tense.
-test.rst:4:45:Odoo.FutureTense:'shall' is future tense.
-test.rst:4:73:Odoo.FutureTense:'about to' is future tense.
+test.rst:1:91:Odoo.FutureTense:'is going to' is future tense.
+test.rst:4:66:Odoo.FutureTense:'is about to' is future tense.

--- a/testdata/FutureTense/test.rst
+++ b/testdata/FutureTense/test.rst
@@ -1,5 +1,4 @@
 A number will be assigned to the :guilabel:`Lot & Serial Number` field when a new product is going
 to be received.
 
-Jose will complete the task by tomorrow, so shall we proceed? He is I'm about to start a new
-project.
+Jose will complete the task by tomorrow, so shall we proceed? He is about to start a new project.


### PR DESCRIPTION
This PR fixes the following issues in v1:
- https://github.com/Felicious/odoo-vale-linter/issues/15
- https://github.com/Felicious/odoo-vale-linter/issues/16
- https://github.com/Felicious/odoo-vale-linter/issues/18
- https://github.com/Felicious/odoo-vale-linter/issues/4
- https://github.com/Felicious/odoo-vale-linter/issues/9
- https://github.com/Felicious/odoo-vale-linter/issues/10

A number of these issues were not a result of the Vale linter, but a conflict with a [spelling extension](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) installed on some user's VS Code.

Be sure to disabled and uninstall the https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker extension. 